### PR TITLE
Fix login page error message color

### DIFF
--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -96,7 +96,7 @@ class Login extends React.Component {
 											<LockOutlinedIcon />
 										),
 									}}
-									error={errors.email && touched.email}
+									error={errors.password && touched.password}
 									margin="normal"
 									required
 									fullWidth

--- a/frontend/src/scss/Form.scss
+++ b/frontend/src/scss/Form.scss
@@ -80,9 +80,7 @@
     background-color: $primary-color;
 }
 
-.MuiFormHelperText-root,
-.Mui-error,
-.Mui-required {
+.MuiFormHelperText-root.Mui-error {
     color: #ec5283;
     margin-left: 5px;
 }

--- a/frontend/src/scss/Form.scss
+++ b/frontend/src/scss/Form.scss
@@ -80,7 +80,9 @@
     background-color: $primary-color;
 }
 
-.MuiFormHelperText-root.Mui-error {
+.MuiFormHelperText-root,
+.Mui-error,
+.Mui-required {
     color: #ec5283;
     margin-left: 5px;
 }


### PR DESCRIPTION
**Feature**
Fix password error message color

**Screenshot**
<img width="534" alt="螢幕快照 2020-05-12 上午12 34 20" src="https://user-images.githubusercontent.com/56378160/81614198-5a9a9f80-93e8-11ea-9aba-ac4e24eaafdd.png">


**Testing**
1. Type-in email, leave the password blank and click sign in button to see if ''Password is required" shows in red.