### PR TITLE
Style progress circle color

### DIFF
--- a/frontend/src/scss/ProgressCircle.scss
+++ b/frontend/src/scss/ProgressCircle.scss
@@ -1,10 +1,18 @@
 .MuiCircularProgress-colorPrimary {
-	color: $primary-color;
+	color: $secondary;
 }
 
 .progress-circle {
 	text-align: center;
 	margin-top: 100px;
+
+	&.is-rep .MuiCircularProgress-colorPrimary {
+		color: $primary-color;
+	}
+
+	&.is-rest .MuiCircularProgress-colorPrimary {
+		color: $tertiary;
+	}
 }
 
 .MuiCircularProgress-static,

--- a/frontend/src/scss/_variables.scss
+++ b/frontend/src/scss/_variables.scss
@@ -1,2 +1,4 @@
 $bg-color: black;
 $primary-color: #30D5C8;
+$secondary: #e77cfe;
+$tertiary: #6f9df8;


### PR DESCRIPTION
**Features**
Progress color will change based on the status.

**Screenshot**
<img width="197" alt="螢幕快照 2020-05-14 上午12 52 36" src="https://user-images.githubusercontent.com/56378160/81869850-6c617b80-957d-11ea-85bb-3c182629680d.png">

<img width="239" alt="螢幕快照 2020-05-14 上午12 52 45" src="https://user-images.githubusercontent.com/56378160/81869858-708d9900-957d-11ea-88de-2db2df95a309.png">
<img width="190" alt="螢幕快照 2020-05-14 上午12 52 52" src="https://user-images.githubusercontent.com/56378160/81869859-71262f80-957d-11ea-9a45-86c1afe97d8f.png">

**Testing**
Click start and check if the color of progress circle changes upon status.