### PR TITLE
Change fraction slash

### DIFF
--- a/frontend/src/Workout.js
+++ b/frontend/src/Workout.js
@@ -194,8 +194,7 @@ class Workout extends React.Component {
 					{ currentRep }
 				</span>
 				{' '}
-				<span className="slash-entity">&frasl;</span>
-				{/* / */}
+				/
 				<span className="denominator">
 					{ reps }
 				</span>
@@ -204,7 +203,6 @@ class Workout extends React.Component {
 					{ currentSet }
 				</span>
 				{' '}
-				{/* <span className="slash-entity">&frasl;</span> */}
 				/
 				<span className="denominator">
 					{ sets }


### PR DESCRIPTION
**Feature**
Instead of fraction‑slash, use the keyboard slash character.

**Screenshot**
<img width="187" alt="螢幕快照 2020-05-14 下午1 10 32" src="https://user-images.githubusercontent.com/56378160/81922215-766a9500-95e4-11ea-869a-01d7b8b86e44.png">


**Testing**
Click each workout and check if the keyboard slash is been used.