### PR TITLE
Render circle before click start

### DIFF
--- a/frontend/src/ProgressCircle.js
+++ b/frontend/src/ProgressCircle.js
@@ -26,14 +26,22 @@ export default class ProgressCircle extends React.Component {
 
 	render() {
 		const { totalTime, remainingTime, status } = this.props;
-		const percentComplete = ( ( totalTime - remainingTime ) / totalTime ) * 100;
+		const elapsedTime = totalTime - remainingTime;
+		const percentComplete = status === 'ready' && elapsedTime === 0
+			? 100
+			: ( elapsedTime / totalTime ) * 100;
 
 		return (
 			<div className={`progress-circle is-${status}`}>
 				<span className="status-text">
 					{this.renderText()}
 				</span>
-				<CircularProgress variant="static" value={percentComplete} size={200} />
+				<CircularProgress
+  					className="circle-before-ready"
+					variant="static"
+					value={percentComplete}
+					size={200}
+				/>
 			</div>
 		);
 	}


### PR DESCRIPTION
**Feature**
Add progress circle before clicking the start button.

**Screenshot**
<img width="286" alt="螢幕快照 2020-05-15 下午10 22 57" src="https://user-images.githubusercontent.com/56378160/82088793-11559300-96fb-11ea-9409-a303a6c72211.png">

**Testing**
1. Click each workout and check if the progress circle rendered before clicking the start button.
1. Click the start button, check if the progress circle still running for ready, hang and rest.
