### PR TITLE
Add link for hangtime logo

### DIFF
--- a/frontend/src/Nav.js
+++ b/frontend/src/Nav.js
@@ -86,7 +86,7 @@ export default class Nav extends React.Component {
 								<LogoutButton />
 							</List>
 						</SwipeableDrawer>
-						<Typography variant="h6" color="inherit">
+						<Typography variant="h6" color="inherit" component={Link} to="/">
 							HANGTIME
 						</Typography>
 						<IconButton

--- a/frontend/src/Nav.scss
+++ b/frontend/src/Nav.scss
@@ -23,3 +23,7 @@
         fill: white;
     }
 }
+
+.MuiTypography-root {
+    text-decoration: none;
+}


### PR DESCRIPTION
**Features**
1. Add the home page link on the hangtime logo.
1. Remove the link style underline for the hangtime logo.

**Screenshot**
<img width="148" alt="螢幕快照 2020-05-15 下午10 46 48" src="https://user-images.githubusercontent.com/56378160/82090420-3c8db180-96fe-11ea-8349-3e86779c3963.png">

**Testing**
Switch between pages and click the hangtime logo and see if link back to the home page(workouts page).