### PR TITLE
Add tooltip for navbar logo

### DIFF
--- a/frontend/src/Nav.js
+++ b/frontend/src/Nav.js
@@ -15,6 +15,7 @@ import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import LogoutButton from './LogoutButton';
 import './Nav.scss';
+import Tooltip from '@material-ui/core/Tooltip';
 
 export default class Nav extends React.Component {
 	constructor( props ) {
@@ -86,9 +87,11 @@ export default class Nav extends React.Component {
 								<LogoutButton />
 							</List>
 						</SwipeableDrawer>
-						<Typography variant="h6" color="inherit" component={Link} to="/">
-							HANGTIME
-						</Typography>
+						<Tooltip title="Home" arrow component={Link} to="/">
+							<Typography variant="h6" color="inherit">
+								HANGTIME
+							</Typography>
+						</Tooltip>
 						<IconButton
 							edge="start"
 							className="menuButton"


### PR DESCRIPTION
**Feature**
Add tooltip 'Home' for navbar logo HANGTIME

**Screentshot**
<img width="130" alt="螢幕快照 2020-05-18 下午8 43 22" src="https://user-images.githubusercontent.com/56378160/82243422-3d198880-9948-11ea-9113-a1d28563d957.png">

**Testing**
1. Go to History and hover over the logo HANGTIME and see if tooltip shows up.
1. Click the logo HANGTIME see if go back to workouts.